### PR TITLE
Typo change

### DIFF
--- a/dji-log-cli/src/exporters/csv.rs
+++ b/dji-log-cli/src/exporters/csv.rs
@@ -47,7 +47,7 @@ fn get_headers(frame: &Frame) -> Vec<String> {
     let mut headers = vec![
         "CUSTOM.dateTime".to_string(),    // Custom date and time of the frame
         "OSD.flyTime".to_string(),        // Flight time in seconds
-        "OSD.lalitude".to_string(),       // Latitude in degrees
+        "OSD.latitude".to_string(),       // Latitude in degrees
         "OSD.longitude".to_string(),      // Longitude in degrees
         "OSD.height".to_string(),         // Height above ground level in meters
         "OSD.heightMax".to_string(),      // Maximum height reached in meters

--- a/dji-log-parser-js/src/lib.rs
+++ b/dji-log-parser-js/src/lib.rs
@@ -96,14 +96,14 @@ impl DJILogWrapper {
             .inner
             .keychains_request()
             .map_err(|e| JsValue::from_str(&e.to_string()))?
-            .fetch_async(&api_key, endpoint.as_deref())
-            .await
+            .fetch(&api_key, endpoint.as_deref())
             .map_err(|e| JsValue::from_str(&e.to_string()))?;
 
         serde_wasm_bindgen::to_value(&keychains)
             .map_err(|e| JsValue::from_str(&e.to_string()))
             .map(|value| value.unchecked_into())
     }
+
 
     /// Retrieves the parsed raw records from the DJI log.
     ///

--- a/dji-log-parser-js/src/lib.rs
+++ b/dji-log-parser-js/src/lib.rs
@@ -96,14 +96,14 @@ impl DJILogWrapper {
             .inner
             .keychains_request()
             .map_err(|e| JsValue::from_str(&e.to_string()))?
-            .fetch(&api_key, endpoint.as_deref())
+            .fetch_async(&api_key, endpoint.as_deref())
+            .await
             .map_err(|e| JsValue::from_str(&e.to_string()))?;
 
         serde_wasm_bindgen::to_value(&keychains)
             .map_err(|e| JsValue::from_str(&e.to_string()))
             .map(|value| value.unchecked_into())
     }
-
 
     /// Retrieves the parsed raw records from the DJI log.
     ///


### PR DESCRIPTION
great work on this parser! It's so useful to some academic work on greenhouse gas emissions I'm doing (https://github.com/gasflux/gasflux) and I'm glad that someone is keeping up with DJI's flight logs.

I noticed a column header typo which I've fixed here, and in order to get it to compile (Ubuntu, x86) I had to make the change in the keychain fetch. I don't speak Rust so I'll just leave it with you to judge whether it's useful.