### PR TITLE
Parse Inspire 1 battery serial numbers

### DIFF
--- a/dji-log-parser/src/record/recover.rs
+++ b/dji-log-parser/src/record/recover.rs
@@ -4,7 +4,7 @@ use serde::Serialize;
 #[cfg(target_arch = "wasm32")]
 use tsify_next::Tsify;
 
-use crate::layout::details::{Platform, ProductType};
+use crate::layout::details::{Platform, ProductType, parse_battery_sn};
 
 #[binread]
 #[derive(Serialize, Debug)]
@@ -29,6 +29,9 @@ pub struct Recover {
     pub camera_sn: String,
     #[br(count = if version <= 7 { 10 } else { 16 }, map = |s: Vec<u8>| String::from_utf8_lossy(&s).trim_end_matches('\0').to_string())]
     pub rc_sn: String,
-    #[br(count = if version <= 7 { 10 } else { 16 }, map = |s: Vec<u8>| String::from_utf8_lossy(&s).trim_end_matches('\0').to_string())]
+    #[br(count = if version <= 7 { 10 } else { 16 })]
+    #[br(temp)]
+    battery_buf: Vec<u8>,
+    #[br(calc = parse_battery_sn(product_type, battery_buf))]
     pub battery_sn: String,
 }


### PR DESCRIPTION
Battery serials on Inspire1 and Inspire1Pro logs were corrupt when using the usual string conversion. 

Before:

     battery_sn: "\u{2}\u{1}\u{5}\u{2}\0\u{5}\u{1}\u{5}\u{1}\u{1}"

After, matching Airdata which calls the value "printed serial" but I haven't been able to confirm. (Note, FlightReader has a bug and the battery serial isn't correct)

    battery_sn: "1151502512"

Other old models may need this formatting too but I can't test. I've tested Phantom4Pro, Matrice600, Mavic2, all use the usual string conversion for `battery_sn`.